### PR TITLE
[BUGFIX] Bad ressources URL when in child theme

### DIFF
--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -79,7 +79,7 @@ class Assets {
 	 * @return string
 	 */
 	public function getThemeUri() {
-		$template_uri = get_template_directory_uri();
+		$template_uri = get_stylesheet_directory_uri();
 		$template_uri = preg_replace( '~/' . preg_quote( APP_THEME_DIR_NAME, '~' ) . '/?$~', '', $template_uri );
 		return $template_uri;
 	}


### PR DESCRIPTION
We use wpemerge in child theme and we noticed that the ressources URL pointed to the parent theme and not the child theme.

This fix aims to resolve this issue.